### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: java
 jdk:
-- oraclejdk7
+- oraclejdk8
 branches:
 only:
 - master


### PR DESCRIPTION
oraclejdk7 has been removed from Travis due to Oracle's withdrawal http://www.webupd8.org/2017/06/why-oracle-java-7-and-6-installers-no.html